### PR TITLE
Add CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test-openssls:
+    name: >-
+      ${{ matrix.openssl }} ${{ matrix.name_extra || '' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, openssl: openssl-3.0.7, fips-enabled: true, name_extra: 'FIPS' }
+          - { os: ubuntu-latest, openssl: openssl-3.0.7 }
+    steps:
+      - name: install deps
+        run: sudo apt install -qq strace
+      - name: repo checkout
+        uses: actions/checkout@v3
+      - if: matrix.fips-enabled
+        run: echo "configure_fips_opt=enable-fips" >> $GITHUB_ENV
+      - name: prepare openssl
+        run: |
+          mkdir -p tmp/build-openssl && cd tmp/build-openssl
+          case ${{ matrix.openssl }} in
+          openssl-*)
+            curl -OL https://ftp.openssl.org/source/${{ matrix.openssl }}.tar.gz
+            tar xf ${{ matrix.openssl }}.tar.gz && cd ${{ matrix.openssl }}
+            # shared is required for 1.0.x.
+            ./Configure --prefix=$HOME/.openssl/${{ matrix.openssl }} --libdir=lib \
+                shared linux-x86_64 $configure_fips_opt
+            make depend
+            ;;
+          *)
+            false
+            ;;
+          esac
+          make -j4
+          make install_sw
+
+      # See <https://github.com/openssl/openssl/blob/master/README-FIPS.md>.
+      - if: matrix.fips-enabled
+        name: prepre openssl fips
+        run: make install_fips
+        working-directory: tmp/build-openssl/${{ matrix.openssl }}
+
+      - if: matrix.fips-enabled
+        run: ls -l $HOME/.openssl/${{ matrix.openssl }}/ssl/fipsmodule.cnf
+
+      - name: compile
+        run:  make
+
+      # See <https://www.openssl.org/docs/manmaster/man7/fips_module.html>
+      # - Selectively making applications use the FIPS module by default
+      - if: matrix.fips-enabled
+        run: sed -e "s|@@OPENSSL_DIR@@|$HOME/.openssl/${{ matrix.openssl }}|" ssl/openssl_fips.cnf.tmpl > ssl/openssl_fips.cnf
+
+      # Debug
+      - if: matrix.fips-enabled
+        run: cat ssl/openssl_fips.cnf
+
+      # Change the default OpenSSL config file for FIPS mode.
+      - if: matrix.fips-enabled
+        run: echo "OPENSSL_CONF=$(pwd)/ssl/openssl_fips.cnf" >> $GITHUB_ENV
+
+      - name: test
+        run: make test
+
+      - if: matrix.fips-enabled
+        name: strace
+        run: make strace-test

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,8 @@ clean :
 test :
 	@echo "Testing..."
 	./$(EXE)
+
+.PHONY: test-strace
+strace-test :
+	@echo "Testing with strace..."
+	strace ./$(EXE)

--- a/ssl/openssl_fips.cnf.tmpl
+++ b/ssl/openssl_fips.cnf.tmpl
@@ -1,0 +1,19 @@
+config_diagnostics = 1
+openssl_conf = openssl_init
+
+# It seems that this .include needs to be absolute path.
+.include @@OPENSSL_DIR@@/ssl/fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+fips = fips_sect
+base = base_sect
+
+[base_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes


### PR DESCRIPTION
This PR is to add the CI to check the FIPS flag on the FIPS enabled OpenSSL 3.

The testing binary returns the `FIPS mode: 1` as expected.

```
$ ./fips_mode
FIPS mode: 1
```

See <https://github.com/junaruga/openssl-fips-test/actions/runs/4439007633/jobs/7790852681#step:12:10>.
