### PR TITLE
Remove "mode" in "FIPS mode".

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,16 +63,16 @@ jobs:
       - if: matrix.fips-enabled
         run: cat ssl/openssl_fips.cnf
 
-      # Change the default OpenSSL config file for FIPS mode.
+      # Change the default OpenSSL config file for FIPS.
       - if: matrix.fips-enabled
         run: echo "OPENSSL_CONF=$(pwd)/ssl/openssl_fips.cnf" >> $GITHUB_ENV
 
-      - name: test FIPS mode get
+      - name: test FIPS get
         run: |
           LD_LIBRARY_PATH=$HOME/.openssl/${{ matrix.openssl }}/lib64 \
             make test
 
-      - name: test FIPS mode set
+      - name: test FIPS set
         run: |
           LD_LIBRARY_PATH=$HOME/.openssl/${{ matrix.openssl }}/lib64 \
             make test-set

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.o
 *.swp
 *~
-/fips_mode
-/fips_mode_set
+/fips
+/fips_set
 /trace

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
-SRCS_GET = fips_mode.c
-SRCS_SET = fips_mode_set.c
+SRCS_GET = fips.c
+SRCS_SET = fips_set.c
 SRCS_TRACE = trace.c
 CFLAGS = $(OPTFLAGS) $(DEBUGFLAGS)
 OPTFLAGS = -O0
@@ -11,8 +11,8 @@ OBJS_GET = $(SRCS_GET:.c=.o)
 OBJS_SET = $(SRCS_SET:.c=.o)
 OBJS_TRACE = $(SRCS_TRACE:.c=.o)
 
-EXE = fips_mode
-EXE_SET = fips_mode_set
+EXE = fips
+EXE_SET = fips_set
 EXE_TRACE = trace
 EXE_ALL= $(EXE) $(EXE_SET) $(EXE_TRACE)
 LIBS = -lssl -lcrypto

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/junaruga/openssl-test/actions/workflows/test.yml/badge.svg)](https://github.com/junaruga/openssl-test/actions/workflows/test.yml)
 
-This repository is to test OpenSSL API especially the FIPS mode related APIs.
+This repository is to test OpenSSL API especially the FIPS related APIs.
 
 ## How to use
 
@@ -62,37 +62,37 @@ default_properties = fips=yes
 
 ### Directly with gcc
 
-Compile the program to test if FIPS mode is enabled or not.
+Compile the program to test if FIPS is enabled or not.
 
 ```
 $ gcc \
   -I /home/jaruga/.local/openssl-3.0.9-fips-debug/include \
   -L /home/jaruga/.local/openssl-3.0.9-fips-debug/lib \
   -lcrypto \
-  -o fips_mode \
-  fips_mode.c
+  -o fips \
+  fips.c
 ```
 
-Run the program. The FIPS mode is off with the command below.
+Run the program. The FIPS is off with the command below.
 
 ```
 $ LD_LIBRARY_PATH=$HOME/.local/openssl-3.0.9-fips-debug/lib/ \
-  ./fips_mode
+  ./fips
 Loaded providers:
   default
-FIPS mode enabled: no
+FIPS enabled: no
 ```
 
-The FIPS mode is on with the command below.
+The FIPS is on with the command below.
 
 ```
 $ LD_LIBRARY_PATH=$HOME/.local/openssl-3.0.9-fips-debug/lib/ \
   OPENSSL_CONF=/home/jaruga/.local/openssl-3.0.9-fips-debug/ssl/openssl_fips.cnf \
-  ./fips_mode
+  ./fips
 Loaded providers:
   fips
   base
-FIPS mode enabled: yes
+FIPS enabled: yes
 ```
 
 ### With make
@@ -110,26 +110,26 @@ Run the commands.
 ```
 $ LD_LIBRARY_PATH=$HOME/.local/openssl-3.0.9-fips-debug/lib/ \
   OPENSSL_CONF=/home/jaruga/.local/openssl-3.0.9-fips-debug/ssl/openssl_fips.cnf \
-  ./fips_mode
+  ./fips
 ...
 
 $ LD_LIBRARY_PATH=$HOME/.local/openssl-3.0.9-fips-debug/lib/ \
   OPENSSL_CONF=/home/jaruga/.local/openssl-3.0.9-fips-debug/ssl/openssl_fips.cnf \
-  ./fips_mode_set
-FIPS mode: 0
-FIPS mode on.
-FIPS mode: 1
-FIPS mode on 2nd time.
-FIPS mode: 1
-FIPS mode off.
-FIPS mode: 0
-FIPS mode off 2nd time.
-FIPS mode: 0
+  ./fips_set
+FIPS: 0
+FIPS on.
+FIPS: 1
+FIPS on 2nd time.
+FIPS: 1
+FIPS off.
+FIPS: 0
+FIPS off 2nd time.
+FIPS: 0
 ```
 
 ## Note
 
-The `FIPS mode provider available: 1` happens when the config file `fipsmodule.cnf` has the line `activate = 1`. You can comment out this line to see the `FIPS mode provider available: 0`.
+The `FIPS provider available: 1` happens when the config file `fipsmodule.cnf` has the line `activate = 1`. You can comment out this line to see the `FIPS provider available: 0`.
 
 ```
 $ cat /path/to/fipsmodule.cnf
@@ -139,7 +139,7 @@ activate = 1
 ...
 ```
 
-The `FIPS mode enabled: yes` happens when the openssl config file `openssl.cnf` has the `default_properties = fips=yes`. You can comment out to see the `FIPS mode enabled: no`
+The `FIPS enabled: yes` happens when the openssl config file `openssl.cnf` has the `default_properties = fips=yes`. You can comment out to see the `FIPS mode enabled: no`
 
 ```
 $ cat /path/to/openssl.cnf

--- a/fips.c
+++ b/fips.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
     OSSL_PROVIDER_do_all(NULL, &print_provider, NULL);
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
-    printf("FIPS mode enabled: %s\n", (fips_enabled) ? "yes" : "no");
+    printf("FIPS enabled: %s\n", (fips_enabled) ? "yes" : "no");
 
     exit(status);
 }

--- a/fips_set.c
+++ b/fips_set.c
@@ -7,43 +7,43 @@ int main(int argc, char *argv[])
     int fips_enabled = 0;
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
-    printf("FIPS mode: %d\n", fips_enabled);
+    printf("FIPS: %d\n", fips_enabled);
 
-    printf("FIPS mode on.\n");
+    printf("FIPS on.\n");
     if (!EVP_default_properties_enable_fips(NULL, 1)) {
         status = EXIT_FAILURE;
         goto err;
     }
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
-    printf("FIPS mode: %d\n", fips_enabled);
+    printf("FIPS: %d\n", fips_enabled);
 
-    printf("FIPS mode on 2nd time.\n");
+    printf("FIPS on 2nd time.\n");
     if (!EVP_default_properties_enable_fips(NULL, 1)) {
         status = EXIT_FAILURE;
         goto err;
     }
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
-    printf("FIPS mode: %d\n", fips_enabled);
+    printf("FIPS: %d\n", fips_enabled);
 
-    printf("FIPS mode off.\n");
+    printf("FIPS off.\n");
     if (!EVP_default_properties_enable_fips(NULL, 0)) {
         status = EXIT_FAILURE;
         goto err;
     }
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
-    printf("FIPS mode: %d\n", fips_enabled);
+    printf("FIPS: %d\n", fips_enabled);
 
-    printf("FIPS mode off 2nd time.\n");
+    printf("FIPS off 2nd time.\n");
     if (!EVP_default_properties_enable_fips(NULL, 0)) {
         status = EXIT_FAILURE;
         goto err;
     }
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
-    printf("FIPS mode: %d\n", fips_enabled);
+    printf("FIPS: %d\n", fips_enabled);
 err:
     exit(status);
 }


### PR DESCRIPTION
The FIPS mode is Fedora/RHEL downstream specific terminology. Use FIPS instead of that.