### PR TITLE
Add a logic to print a provider number.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJS_TRACE = $(SRCS_TRACE:.c=.o)
 OBJS_PRINTV = $(SRCS_PRINTV:.c=.o)
 # Customize the OpenSSL to compile with.
 OPENSSL_DIR =
-# OPENSSL_DIR = /home/jaruga/.local/openssl-3.2.0-dev-fips-debug-6d38ccedb2
+# OPENSSL_DIR = /home/jaruga/.local/openssl-3.2.0-dev-fips-debug-2acb0d363c
 # OPENSSL_DIR = /home/jaruga/.local/libressl-6650dce
 OPENSSL_INC_DIR = $(OPENSSL_DIR)/include
 OPENSSL_LIB_DIR = $(OPENSSL_DIR)/lib

--- a/fips.c
+++ b/fips.c
@@ -8,6 +8,12 @@ static int print_provider(OSSL_PROVIDER *prov, void *unused)
     return 1;
 }
 
+static int count_provider(OSSL_PROVIDER *prov, void *cbdata)
+{
+    int *num_p = (int *)cbdata;
+    (*num_p)++;
+}
+
 int main(int argc, char *argv[])
 {
     int status = EXIT_SUCCESS;
@@ -15,6 +21,11 @@ int main(int argc, char *argv[])
 
     printf("Loaded providers:\n");
     OSSL_PROVIDER_do_all(NULL, &print_provider, NULL);
+
+    /* Count providers */
+    int provider_num = 0;
+    OSSL_PROVIDER_do_all(NULL, &count_provider, (void*)&provider_num);
+    printf("Loaded provider number: %d\n", provider_num);
 
     fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
     printf("FIPS enabled: %s\n", (fips_enabled) ? "yes" : "no");


### PR DESCRIPTION
The result is like this.

```
$ LD_LIBRARY_PATH=/home/jaruga/.local/openssl-3.2.0-dev-fips-debug-2acb0d363c/lib \
  OPENSSL_CONF="/home/jaruga/.local/openssl-3.2.0-dev-fips-debug-2acb0d363c/ssl/openssl_fips.cnf" \
  ./fips
Loaded providers:
  fips
  base
Loaded provider number: 2
FIPS enabled: yes
```
